### PR TITLE
Enable clean restart of the GEOPM LDMS Sampler

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -508,6 +508,7 @@ AS_IF([test "x$with_geopm" != xno], [
         AC_CHECK_HEADER(geopm_pio.h, [have_geopm=yes], [have_geopm=no])
         AC_CHECK_HEADER(geopm_topo.h, [have_geopm=yes], [have_geopm=no])
         AC_CHECK_LIB([geopmd], [geopm_pio_push_signal], [have_geopm=yes], [have_geopm=no])
+        AC_CHECK_LIB([geopmd], [geopm_pio_reset], [have_geopm=yes], [have_geopm=no])
         CPPFLAGS=$save_CPPFLAGS
         CFLAGS=$save_CFLAGS
         LDFLAGS=$save_LDFLAGS

--- a/ldms/src/contrib/sampler/geopm_sampler/README.md
+++ b/ldms/src/contrib/sampler/geopm_sampler/README.md
@@ -39,15 +39,15 @@ GEOPM LDMS sampler, if need be.
 
 
 The bash script below shows an example source build that uses the
-``v2.0.0+rc1`` release candidate:
+``v2.0.0+rc2`` release candidate:
 
     #!/bin/bash
     # Build GEOPM libraries
     GEOPM_URL="https://github.com/geopm/geopm/releases/download"
-    GEOPM_RELEASE="/v2.0.0%2Brc1/geopm-service-2.0.0.rc1.tar.gz"
+    GEOPM_RELEASE="/v2.0.0%2Brc2/geopm-service-2.0.0.rc2.tar.gz"
     wget ${GEOPM_URL}${GEOPM_RELEASE}
-    tar xvf geopm-service-2.0.0.rc1.tar.gz
-    cd geopm-service-2.0.0~rc1/
+    tar xvf geopm-service-2.0.0.rc2.tar.gz
+    cd geopm-service-2.0.0~rc2/
     GEOPM_PREFIX=$HOME/build/geopm
     # Use configure --help for details on enabling optional accelerator support
     ./configure --prefix=${GEOPM_PREFIX} --libdir=${GEOPM_PREFIX}/lib64

--- a/ldms/src/contrib/sampler/geopm_sampler/ldms_geopm_sampler.c
+++ b/ldms/src/contrib/sampler/geopm_sampler/ldms_geopm_sampler.c
@@ -350,6 +350,13 @@ int ldms_geopm_sampler_sample_batch(void)
 	return rc;
 }
 
+void ldms_geopm_sampler_reset(void)
+{
+	g_metric_offset = 0;
+	g_metric_cnt = 0;
+	geopm_pio_reset();
+}
+
 static int create_metric_set(void)
 {
 	ldms_schema_t schema;
@@ -558,6 +565,9 @@ static void term(struct ldmsd_plugin *self)
 	}
 	if (g_set) {
 		ldms_set_delete(g_set);
+	}
+	if (g_metric_cnt != 0) {
+		ldms_geopm_sampler_reset();
 	}
 	g_set = NULL;
 }

--- a/ldms/src/contrib/sampler/geopm_sampler/ldms_geopm_sampler.h
+++ b/ldms/src/contrib/sampler/geopm_sampler/ldms_geopm_sampler.h
@@ -201,3 +201,10 @@ int ldms_geopm_sampler_read_batch(void);
  *  @returns Zero on success, GEOPM error code on failure.
  */
 int ldms_geopm_sampler_sample_batch(void);
+
+/**
+ *
+ *  @brief Reset the geopm sampler state
+ *
+ */
+void ldms_geopm_sampler_reset(void);

--- a/ldms/src/contrib/sampler/geopm_sampler/ldms_geopm_sampler_test.c
+++ b/ldms/src/contrib/sampler/geopm_sampler/ldms_geopm_sampler_test.c
@@ -187,6 +187,9 @@ static int run(const char *path)
 	if (!err) {
 		err = ldms_geopm_sampler_sample_batch();
 	}
+	if (!err) {
+		ldms_geopm_sampler_reset();
+	}
 	return err;
 }
 
@@ -199,7 +202,12 @@ int main(int argc, char **argv)
 	}
 
 	ldms_geopm_sampler_set_log(test_logger);
+
 	err = run(argv[1]);
+	if (err == 0) {
+		// Run twice to validate reset
+		err = run(argv[1]);
+	}
 
 	if (!err) {
 		printf("\nSUCCESS\n");

--- a/ldms/src/contrib/sampler/geopm_sampler/ldms_geopm_sampler_test.expect
+++ b/ldms/src/contrib/sampler/geopm_sampler/ldms_geopm_sampler_test.expect
@@ -7,5 +7,14 @@ ldms_geopm_sampler: metric_0 = XXXX
 ldms_geopm_sampler: metric_1 = XXXX
 ldms_geopm_sampler: metric_2 = XXXX
 ldms_geopm_sampler: metric_3 = XXXX
+ldms_geopm_sampler: Success opening configuration file: 'ldms_geopm_sampler_test.conf'
+ldms_geopm_sampler: Adding metric: TIME_board_0
+ldms_geopm_sampler: Adding metric: TIME_package_0
+ldms_geopm_sampler: Adding metric: TIME_core_0
+ldms_geopm_sampler: Adding metric: TIME_cpu_0
+ldms_geopm_sampler: metric_0 = XXXX
+ldms_geopm_sampler: metric_1 = XXXX
+ldms_geopm_sampler: metric_2 = XXXX
+ldms_geopm_sampler: metric_3 = XXXX
 
 SUCCESS


### PR DESCRIPTION
- Add call to geopm_pio_reset in the term() callback
- Update source build instructions to point to v2.0.0~rc2
- Note v2.0.0~rc1 does not have the geopm_pio_reset() api
- Add check for new api geopm_pio_reset() to the configure script

Signed-off-by: Christopher M. Cantalupo <christopher.m.cantalupo@intel.com>